### PR TITLE
Locks web3dart v2.5.1

### DIFF
--- a/magic_demo/pubspec.yaml
+++ b/magic_demo/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
 
   # Live imports
   magic_sdk: ^2.0.0
-  magic_ext_oauth: ^0.3.1
+  magic_ext_oauth: ^0.3.2
   magic_ext_tezos: ^0.2.0
   magic_ext_solana: ^0.2.0
 

--- a/packages/magic_ext/oauth/pubspec.yaml
+++ b/packages/magic_ext/oauth/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   flutter:
     sdk: flutter
   magic_sdk: ^2.0.0
-#  magic_sdk:
-#    path: "../../magic_sdk"
+  # magic_sdk:
+  #  path: "../../magic_sdk"
   uri: ^1.0.0
   flutter_web_auth: ^0.5.0
   crypto: ^3.0.1

--- a/packages/magic_ext/solana/pubspec.yaml
+++ b/packages/magic_ext/solana/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   magic_sdk: ^2.0.0
+  # magic_sdk:
+  #  path: "../../magic_sdk"
   solana: ^0.26.0
   json_annotation: ^4.5.0
 

--- a/packages/magic_ext/tezos/pubspec.yaml
+++ b/packages/magic_ext/tezos/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   magic_sdk: ^2.0.0
+  # magic_sdk:
+  #  path: "../../magic_sdk"
   blockchain_signer: ^0.1.0
   json_annotation: ^4.5.0
 

--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_sdk
 description: This is your entry-point to secure, passwordless authentication for your iOS or Android-based Flutter app.
-version: 2.0.1
+version: 2.0.2
 homepage: https://magic.link
 repository: https://github.com/magiclabs/magic-flutter
 
@@ -14,7 +14,7 @@ dependencies:
   package_info_plus: ^3.0.2
   webview_flutter: ^3.0.4
   json_annotation: ^4.5.0
-  web3dart: ^2.5.1
+  web3dart: 2.5.1
   blockchain_signer: ^0.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Latest version of package causes the following error:

```
Error: The non-abstract class 'RpcProvider' is missing
implementations for these members:
 - RpcService.url
Try to either
 - provide an implementation,
 - inherit an implementation from a superclass or mixin,
 - mark the class as abstract, or
 - provide a 'noSuchMethod' implementation.
 ```