### PR TITLE
Upgrade to latest `webview_flutter` (v4.2.0) `web3dart` (v2.6.1) and solana (v0.29.0)

### DIFF
--- a/magic_demo/android/build.gradle
+++ b/magic_demo/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/magic_demo/ios/Podfile.lock
+++ b/magic_demo/ios/Podfile.lock
@@ -27,8 +27,8 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_web_auth: c25208760459cec375a3c39f6a8759165ca0fa4d
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
-  webview_flutter_wkwebview: b7e70ef1ddded7e69c796c7390ee74180182971f
+  webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/magic_demo/ios/Runner.xcodeproj/project.pbxproj
+++ b/magic_demo/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -156,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -200,10 +200,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -253,6 +255,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/magic_demo/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/magic_demo/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/magic_demo/ios/Runner/Info.plist
+++ b/magic_demo/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/magic_demo/lib/tabs/solana.dart
+++ b/magic_demo/lib/tabs/solana.dart
@@ -58,7 +58,7 @@ class _SolanaPageState extends State<SolanaPage> {
 
                 // Sign Transaction Remotely using Magic Auth
                 var transactionSignature = await magic.solana.signTransaction(
-                    recentBlockhash,
+                    recentBlockhash.value,
                     message,
                     instruction.accounts
                 );
@@ -83,9 +83,11 @@ class _SolanaPageState extends State<SolanaPage> {
                   lamports: 1,
                 );
 
+                // recentBlockhash
+                var recentBlockhashWithCommitment = await client.getRecentBlockhash(commitment: Commitment.confirmed);
 
                 final tx = await signTransaction(
-                  await client.getRecentBlockhash(commitment: Commitment.confirmed),
+                  recentBlockhashWithCommitment.value,
                   Message(instructions: [instruction]),
                   [sampleSigner],
                 );

--- a/magic_demo/pubspec.yaml
+++ b/magic_demo/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   magic_sdk: ^2.0.0
   magic_ext_oauth: ^0.3.2
   magic_ext_tezos: ^0.2.0
-  magic_ext_solana: ^0.2.0
+  magic_ext_solana: ^0.3.0
 
   tezart:
     git: https://github.com/Ethella/tezart.git

--- a/magic_demo/pubspec.yaml
+++ b/magic_demo/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
 
   # Live imports
-  magic_sdk: ^2.0.0
+  magic_sdk: ^3.0.0
   magic_ext_oauth: ^0.3.2
   magic_ext_tezos: ^0.2.0
   magic_ext_solana: ^0.3.0

--- a/magic_demo/pubspec.yaml
+++ b/magic_demo/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
 
   tezart:
     git: https://github.com/Ethella/tezart.git
-  solana: ^0.26.0
+  solana: ^0.29.0
 
 #  # Local imports
 #  magic_sdk:

--- a/packages/magic_ext/oauth/README.md
+++ b/packages/magic_ext/oauth/README.md
@@ -12,7 +12,7 @@ Add `magic_sdk` to your `pubspec.yaml`:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^2.0.0
+  magic_sdk: ^3.0.0
   magic_ext_oauth: ^0.3.0
 ```
 

--- a/packages/magic_ext/oauth/pubspec.yaml
+++ b/packages/magic_ext/oauth/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^2.0.0
+  magic_sdk: ^3.0.0
   # magic_sdk:
   #  path: "../../magic_sdk"
   uri: ^1.0.0

--- a/packages/magic_ext/solana/README.md
+++ b/packages/magic_ext/solana/README.md
@@ -12,7 +12,7 @@ Add `magic_sdk` to your `pubspec.yaml`:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^2.0.0
+  magic_sdk: ^3.0.0
   magic_ext_solana: ^0.3.0
 
   # Magic Flutter SDK depends on crypto-please Solana SDK to construct instructions.  

--- a/packages/magic_ext/solana/README.md
+++ b/packages/magic_ext/solana/README.md
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   magic_sdk: ^2.0.0
-  magic_ext_solana: ^0.2.0
+  magic_ext_solana: ^0.3.0
 
   # Magic Flutter SDK depends on crypto-please Solana SDK to construct instructions.  
   solana: ^0.26.0

--- a/packages/magic_ext/solana/lib/magic_ext_solana.dart
+++ b/packages/magic_ext/solana/lib/magic_ext_solana.dart
@@ -67,7 +67,7 @@ class SolanaSigner extends BlockchainModule {
               MgboxTransactionSignature.fromJson(json as Map<String, dynamic>));
       var result = relayerResponse.response.result;
       return TransactionSignature(
-          messageBytes: compiledMessage.data,
+          messageBytes: compiledMessage.instructions.first.data,
           rawTransaction: result.rawTransaction.convertToUint8List(),
           signature: result.signature
               .map((e) => SolanaSignature(

--- a/packages/magic_ext/solana/lib/magic_ext_solana.dart
+++ b/packages/magic_ext/solana/lib/magic_ext_solana.dart
@@ -67,7 +67,7 @@ class SolanaSigner extends BlockchainModule {
               MgboxTransactionSignature.fromJson(json as Map<String, dynamic>));
       var result = relayerResponse.response.result;
       return TransactionSignature(
-          messageBytes: compiledMessage.instructions.first.data,
+          messageBytes: compiledMessage.toByteArray(),
           rawTransaction: result.rawTransaction.convertToUint8List(),
           signature: result.signature
               .map((e) => SolanaSignature(

--- a/packages/magic_ext/solana/pubspec.yaml
+++ b/packages/magic_ext/solana/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   magic_sdk: ^2.0.0
   # magic_sdk:
   #  path: "../../magic_sdk"
-  solana: ^0.26.0
+  solana: ^0.29.0
   json_annotation: ^4.5.0
 
 dev_dependencies:

--- a/packages/magic_ext/solana/pubspec.yaml
+++ b/packages/magic_ext/solana/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^2.0.0
+  magic_sdk: ^3.0.0
   # magic_sdk:
   #  path: "../../magic_sdk"
   solana: ^0.29.0

--- a/packages/magic_ext/solana/pubspec.yaml
+++ b/packages/magic_ext/solana/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_ext_solana
 description: A Magic extension to enable signing with Solana on Flutter. Magic SDK is your entry-point to integrating passwordless authentication inside your application.
-version: 0.2.0
+version: 0.3.0
 homepage: https://magic.link
 repository: https://github.com/magiclabs/magic-flutter
 

--- a/packages/magic_ext/tezos/README.md
+++ b/packages/magic_ext/tezos/README.md
@@ -12,7 +12,7 @@ Add `magic_sdk` to your `pubspec.yaml`:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^2.0.0
+  magic_sdk: ^3.0.0
   magic_ext_tezos: ^0.2.0
 
   # Please use a forked version of tezart, that have Remote signer enabled

--- a/packages/magic_ext/tezos/pubspec.yaml
+++ b/packages/magic_ext/tezos/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^2.0.0
+  magic_sdk: ^3.0.0
   # magic_sdk:
   #  path: "../../magic_sdk"
   blockchain_signer: ^0.1.0

--- a/packages/magic_sdk/README.md
+++ b/packages/magic_sdk/README.md
@@ -12,7 +12,7 @@ Add `magic_sdk` to your `pubspec.yaml`:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^0.3.0
+  magic_sdk: ^3.0.0
 ```
 
 Run the following command to install dependencies

--- a/packages/magic_sdk/lib/modules/base_module.dart
+++ b/packages/magic_sdk/lib/modules/base_module.dart
@@ -10,23 +10,23 @@ class BaseModule {
 
   BaseModule(this.provider);
 
-  /// Returns <JavascriptMessage> here to decode in the last step.
+  /// Returns <JavaScriptMessage> here to decode in the last step.
   /// As Dart doesn't support method return type inference. So we need to surface raw message and
   /// let the type in interface call to deserialize
-  Future<JavascriptMessage> sendToProvider(
+  Future<JavaScriptMessage> sendToProvider(
       {required Enum method, List<dynamic>? params}) async {
     MagicRPCRequest<List<dynamic>> request = MagicRPCRequest<List<dynamic>>(
         method: toShortString(method), params: params ?? []);
     return provider.send(
-        request: request, completer: Completer<JavascriptMessage>());
+        request: request, completer: Completer<JavaScriptMessage>());
   }
 
-  Future<JavascriptMessage> sendToProviderWithMap(
+  Future<JavaScriptMessage> sendToProviderWithMap(
       {required Enum method, Map<String, dynamic>? params}) async {
     MagicRPCRequest<Map<String, dynamic>> request =
         MagicRPCRequest<Map<String, dynamic>>(
             method: toShortString(method), params: params ?? {});
     return provider.send(
-        request: request, completer: Completer<JavascriptMessage>());
+        request: request, completer: Completer<JavaScriptMessage>());
   }
 }

--- a/packages/magic_sdk/lib/provider/rpc_provider.dart
+++ b/packages/magic_sdk/lib/provider/rpc_provider.dart
@@ -20,9 +20,9 @@ class RpcProvider implements RpcService {
   RpcProvider(this._overlay, {this.rpcUrl = ""});
 
   /// Sends message to relayer
-  Future<JavascriptMessage> send(
+  Future<JavaScriptMessage> send(
       {required MagicRPCRequest request,
-      required Completer<JavascriptMessage> completer}) async {
+      required Completer<JavaScriptMessage> completer}) async {
     var msgType = OutboundMessageType.MAGIC_HANDLE_REQUEST;
     var encodedParams = await URLBuilder.instance.encodedParams;
 
@@ -44,7 +44,7 @@ class RpcProvider implements RpcService {
     var request = MagicRPCRequest(method: function, params: params);
 
     /* Send the RPCRequest to Magic Relayer and decode it by using RPCResponse from web3dart */
-    return send(request: request, completer: Completer<JavascriptMessage>())
+    return send(request: request, completer: Completer<JavaScriptMessage>())
         .then((jsMsg) {
       var relayerResponse = RelayerResponse<dynamic>.fromJson(
           json.decode(jsMsg.message), (json) => json as dynamic);

--- a/packages/magic_sdk/lib/provider/rpc_provider.dart
+++ b/packages/magic_sdk/lib/provider/rpc_provider.dart
@@ -51,4 +51,16 @@ class RpcProvider implements RpcService {
       return relayerResponse.response;
     });
   }
+
+  @override
+  noSuchMethod(Invocation invocation) {
+    // Handle the case when a nonexistent method or property is accessed.
+    print('Error: Attempted to call a nonexistent method or property: ${invocation.memberName}');
+    return super.noSuchMethod(invocation);
+  }
+
+  @override
+  String toString() {
+    return 'RpcProvider(_overlay: $_overlay, rpcUrl: $rpcUrl)';
+  }
 }

--- a/packages/magic_sdk/lib/provider/rpc_provider.dart
+++ b/packages/magic_sdk/lib/provider/rpc_provider.dart
@@ -61,6 +61,6 @@ class RpcProvider implements RpcService {
 
   @override
   String toString() {
-    return 'RpcProvider(_overlay: $_overlay, rpcUrl: $rpcUrl)';
+    return 'RpcProvider(_overlay: ***, rpcUrl: $rpcUrl)';
   }
 }

--- a/packages/magic_sdk/lib/relayer/webview.dart
+++ b/packages/magic_sdk/lib/relayer/webview.dart
@@ -40,7 +40,7 @@ class WebViewRelayer extends StatefulWidget {
           json.encode({"data": messageMap}).replaceAll("\\", "");
       // debugPrint("Send Message ===> \n $jsonString");
 
-      webViewCtrl.runJavascript(
+      webViewCtrl.runJavaScript(
           "window.dispatchEvent(new MessageEvent('message', $jsonString));");
 
       // Recursively dequeue till queue is Empty
@@ -56,7 +56,7 @@ class WebViewRelayer extends StatefulWidget {
     _isOverlayVisible = false;
   }
 
-  void handleResponse(JavascriptMessage message) {
+  void handleResponse(JavaScriptMessage message) {
     try {
       var json = message.decode();
 
@@ -71,7 +71,7 @@ class WebViewRelayer extends StatefulWidget {
       // get callbacks in the handlers map
       var completer = _messageHandlers[id];
 
-      // Surface the Raw JavascriptMessage back to the function call so it can converted back to Result type
+      // Surface the Raw JavaScriptMessage back to the function call so it can converted back to Result type
       // Only decode when result is not null, so the result is not null
       if (result != null) {
         completer!.complete(message);
@@ -149,7 +149,7 @@ class WebViewRelayerState extends State<WebViewRelayer> {
 }
 
 /// Extended utilities to help to decode JS Message
-extension MessageType on JavascriptMessage {
+extension MessageType on JavaScriptMessage {
   Map<String, dynamic> decode() {
     return json.decode(message);
   }

--- a/packages/magic_sdk/lib/relayer/webview.dart
+++ b/packages/magic_sdk/lib/relayer/webview.dart
@@ -93,59 +93,77 @@ class WebViewRelayer extends StatefulWidget {
 }
 
 class WebViewRelayerState extends State<WebViewRelayer> {
+  String? url;
+
   @override
   void initState() {
     super.initState();
-    // Enable hybrid composition.
-    if (Platform.isAndroid) WebView.platform = SurfaceAndroidWebView();
+    initializeURL();
+  }
+
+  Future<void> initializeURL() async {
+    try {
+      url = await URLBuilder.instance.url;
+      if (url != null) {
+        loadWebView();
+      } else {
+        setState(() {
+          // Show an error message or handle the absence of URL
+        });
+      }
+    } catch (error) {
+      print('Error occurred: $error');
+      setState(() {
+        // Show an error message or handle the error
+      });
+    }
+  }
+
+  void loadWebView() {
+    widget.webViewCtrl = WebViewController();
+    widget.webViewCtrl.setJavaScriptMode(JavaScriptMode.unrestricted);
+    widget.webViewCtrl.addJavaScriptChannel('magicFlutter',
+        onMessageReceived: (JavaScriptMessage message) {
+      onMessageReceived(message);
+    });
+    widget.webViewCtrl.loadRequest(Uri.parse(url!));
+  }
+
+  void onMessageReceived(JavaScriptMessage message) {
+    // debugPrint("Received message <=== \n ${message.message}");
+
+    if (message.getMsgType() ==
+        InboundMessageType.MAGIC_OVERLAY_READY.toShortString()) {
+      widget._overlayReady = true;
+      widget._dequeue();
+    } else if (message.getMsgType() ==
+        InboundMessageType.MAGIC_SHOW_OVERLAY.toShortString()) {
+      setState(() {
+        // setState can only be accessed in this context
+        widget._isOverlayVisible = true;
+      });
+    } else if (message.getMsgType() ==
+        InboundMessageType.MAGIC_HIDE_OVERLAY.toShortString()) {
+      setState(() {
+        widget._isOverlayVisible = false;
+      });
+    } else if (message.getMsgType() ==
+        InboundMessageType.MAGIC_HANDLE_EVENT.toShortString()) {
+      //Todo PromiseEvent
+    } else if (message.getMsgType() ==
+        InboundMessageType.MAGIC_HANDLE_RESPONSE.toShortString()) {
+      widget.handleResponse(message);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    void onMessageReceived(JavascriptMessage message) {
-      // debugPrint("Received message <=== \n ${message.message}");
-
-      if (message.getMsgType() ==
-          InboundMessageType.MAGIC_OVERLAY_READY.toShortString()) {
-        widget._overlayReady = true;
-        widget._dequeue();
-      } else if (message.getMsgType() ==
-          InboundMessageType.MAGIC_SHOW_OVERLAY.toShortString()) {
-        setState(() {
-          // setState can only be accessed in this context
-          widget._isOverlayVisible = true;
-        });
-      } else if (message.getMsgType() ==
-          InboundMessageType.MAGIC_HIDE_OVERLAY.toShortString()) {
-        setState(() {
-          widget._isOverlayVisible = false;
-        });
-      } else if (message.getMsgType() ==
-          InboundMessageType.MAGIC_HANDLE_EVENT.toShortString()) {
-        //Todo PromiseEvent
-      } else if (message.getMsgType() ==
-          InboundMessageType.MAGIC_HANDLE_RESPONSE.toShortString()) {
-        widget.handleResponse(message);
-      }
-    }
-
     return Visibility(
-        visible: widget._isOverlayVisible,
-        maintainState: true,
-        child: WebView(
-          debuggingEnabled: true,
-          javascriptMode: JavascriptMode.unrestricted,
-          javascriptChannels: {
-            JavascriptChannel(
-                name: 'magicFlutter', onMessageReceived: onMessageReceived)
-          },
-          onWebViewCreated: (WebViewController w) async {
-            widget.webViewCtrl = w;
-            String url = await URLBuilder.instance.url;
-            w.loadUrl(url);
-          },
-        ));
-  }
+      visible: widget._isOverlayVisible,
+      maintainState: true,
+      child: WebViewWidget(controller: widget.webViewCtrl),
+    );
+  } 
 }
 
 /// Extended utilities to help to decode JS Message

--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_sdk
 description: This is your entry-point to secure, passwordless authentication for your iOS or Android-based Flutter app.
-version: 2.0.2
+version: 3.0.0
 homepage: https://magic.link
 repository: https://github.com/magiclabs/magic-flutter
 

--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
   package_info_plus: ^3.0.2
-  webview_flutter: ^3.0.4
+  webview_flutter: ^4.2.0
   json_annotation: ^4.5.0
-  web3dart: 2.5.1
+  web3dart: ^2.6.1
   blockchain_signer: ^0.1.0
 
 dev_dependencies:

--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   package_info_plus: ^3.0.2
   webview_flutter: ^4.2.0
   json_annotation: ^4.5.0
-  web3dart: ^2.6.1
+  web3dart: 2.6.1
   blockchain_signer: ^0.1.0
 
 dev_dependencies:


### PR DESCRIPTION
- Migrates packages to latest versions of [webview_flutter](https://pub.dev/packages/webview_flutter), [web3dart](https://pub.dev/packages/web3dart), and [solana](https://pub.dev/packages/solana)
- Fixes https://github.com/magiclabs/magic-flutter/issues/22
- Address [Solana dependency conflict with cryptography package](https://github.com/espresso-cash/espresso-cash-public/pull/874) via upgrade to `v0.29.0`
- Updates away from[ deprecated solana `RecentBlockHash`](https://pub.dev/documentation/solana/latest/solana/RpcClient/getRecentBlockhash.html) to [new `LatestBlockHash`](https://pub.dev/documentation/solana/latest/dto/LatestBlockhashResult-class.html) implementation
- Replaces `WebView`  w/ `WebView Widget` [as per migration docs](https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter#replacing-webview-functionality).

## Screenshots and GIFS

### `getAccount()`
#### iOS
![2023-05-15 10 36 12](https://github.com/magiclabs/magic-flutter/assets/13407884/c3539c46-4477-4708-a9da-4dda2d884f3e)

### Android
![2023-05-16 16 02 55](https://github.com/magiclabs/magic-flutter/assets/13407884/5eaa5d0f-acef-4d76-95c5-5379c4648e08)

### `personalSign()`
#### iOS
![2023-05-15 10 37 26](https://github.com/magiclabs/magic-flutter/assets/13407884/cbb83e3c-ae69-49c6-a437-60364d4838ee)

### Android
![2023-05-16 16 03 08](https://github.com/magiclabs/magic-flutter/assets/13407884/237d12d1-257b-413b-9e71-14f8580dba64)

### `SignTypedData()`

#### iOS
![2023-05-16 15 57 52](https://github.com/magiclabs/magic-flutter/assets/13407884/142aff6a-5d3f-4e68-8a56-ffeaa16644b4)

### Android
![2023-05-16 16 03 19](https://github.com/magiclabs/magic-flutter/assets/13407884/f1e57d2c-df36-4e65-98bf-b2a2c7c9aad6)
