### PR TITLE
Fix minimum_ios_version syntax + Bump demo version

### DIFF
--- a/magic_demo/pubspec.yaml
+++ b/magic_demo/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
 
   # Live imports
-  magic_sdk: ^4.1.1
+  magic_sdk: ^4.1.2
   magic_ext_oauth: ^0.3.4
   magic_ext_tezos: ^0.2.2
   magic_ext_solana: ^0.3.1

--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -29,15 +29,15 @@ dev_dependencies:
   json_serializable: ^6.2.0
   flutter_lints: ^2.0.1
 
+platforms:
+  ios:
+    minimum_ios_version: "14.0"
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter.
 flutter:
-  plugin:
-    platforms:
-      ios:
-        minimum_ios_version: "14.0"
 
   # To add assets to your package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
Got the following error when attempting to push up the last PR:

```
pubspec.yaml allows Flutter SDK version prior to 1.20.0, which does not support having no `ios/` folder.
Please consider increasing the Flutter SDK requirement to ^1.20.0 or higher (environment.sdk.flutter) or create an `ios/` folder.

See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
```

This updates the syntax to match the latest version of flutter