### PR TITLE
Add `proguard-rules` to Demo App

### DIFF
--- a/magic_demo/android/app/proguard-rules.pro
+++ b/magic_demo/android/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# Preserve annotated Javascript interface methods.
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>; 
+}

--- a/magic_demo/android/app/src/main/AndroidManifest.xml
+++ b/magic_demo/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.magic_demo">
-   <application
+
+    <!-- Add this line to specify that your app needs internet permission -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+    <application
         android:label="magic_demo"
         android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher">


### PR DESCRIPTION
-  Adds `proguard-rules` to Demo to permit app to run on Android release mode (fixes https://github.com/magiclabs/magic-flutter/issues/43)
- Adds `internet permissions` to release `Android.Manifest`