### PR TITLE
Update Flutter SDK Dependencies

### DIFF
--- a/magic_demo/ios/Podfile
+++ b/magic_demo/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/magic_demo/ios/Podfile.lock
+++ b/magic_demo/ios/Podfile.lock
@@ -34,13 +34,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
-  agent_dart: 60b2c0137d382ac8e72defc2a6d8907d94d92bd7
+  agent_dart: b46ed8b9fdc343017e835108e2275124166df4f7
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_web_auth: c25208760459cec375a3c39f6a8759165ca0fa4d
-  package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
+  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   secp256r1: c4054eb1aa9e47c266a9c2914e9c8c5dd17b8ffd
   webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
 
-PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
+PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.2

--- a/magic_demo/pubspec.yaml
+++ b/magic_demo/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 2.0.0+2
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -38,7 +38,7 @@ dependencies:
   magic_ext_solana: ^0.3.2
 
   tezart:
-    git: https://github.com/Ethella/tezart.git
+    git: https://github.com/magiclabs/tezart
   solana: ^0.30.0
 
 #  # Local imports

--- a/magic_demo/pubspec.yaml
+++ b/magic_demo/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -32,14 +32,14 @@ dependencies:
 
 
   # Live imports
-  magic_sdk: ^4.1.2
-  magic_ext_oauth: ^0.3.4
-  magic_ext_tezos: ^0.2.2
-  magic_ext_solana: ^0.3.1
+  magic_sdk: ^5.0.0
+  magic_ext_oauth: ^0.3.5
+  magic_ext_tezos: ^0.2.3
+  magic_ext_solana: ^0.3.2
 
   tezart:
     git: https://github.com/Ethella/tezart.git
-  solana: ^0.29.0
+  solana: ^0.30.0
 
 #  # Local imports
 #  magic_sdk:

--- a/packages/magic_ext/oauth/pubspec.yaml
+++ b/packages/magic_ext/oauth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_ext_oauth
 description: A Magic oauth extension to support Magic social login authentication
-version: 0.3.4
+version: 0.3.5
 homepage: https://magic.link
 repository: https://github.com/magiclabs/magic-flutter
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^4.0.0
+  magic_sdk: ^5.0.0
   # magic_sdk:
   #  path: "../../magic_sdk"
   uri: ^1.0.0

--- a/packages/magic_ext/solana/pubspec.yaml
+++ b/packages/magic_ext/solana/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_ext_solana
 description: A Magic extension to enable signing with Solana on Flutter. Magic SDK is your entry-point to integrating passwordless authentication inside your application.
-version: 0.3.1
+version: 0.3.2
 homepage: https://magic.link
 repository: https://github.com/magiclabs/magic-flutter
 
@@ -11,10 +11,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^4.0.0
+  magic_sdk: ^5.0.0
   # magic_sdk:
   #  path: "../../magic_sdk"
-  solana: ^0.29.0
+  solana: ^0.30.0
   json_annotation: ^4.5.0
 
 dev_dependencies:

--- a/packages/magic_ext/tezos/pubspec.yaml
+++ b/packages/magic_ext/tezos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_ext_tezos
 description: A Magic extension to enable interaction with Tezos on Flutter.
-version: 0.2.2
+version: 0.2.3
 homepage: https://magic.link
 repository: https://github.com/magiclabs/magic-flutter
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  magic_sdk: ^4.0.0
+  magic_sdk: ^5.0.0
   # magic_sdk:
   #  path: "../../magic_sdk"
   blockchain_signer: ^0.1.0

--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -1,26 +1,27 @@
 name: magic_sdk
 description: This is your entry-point to secure, passwordless authentication for your iOS or Android-based Flutter app.
-version: 4.1.3
+version: 5.0.0
 homepage: https://magic.link
 repository: https://github.com/magiclabs/magic-flutter
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^3.0.2
+  package_info_plus: ^4.2.0
   webview_flutter: ^4.2.0
   json_annotation: ^4.5.0
-  web3dart: 2.6.1
+  web3dart: 2.7.0
   blockchain_signer: ^0.1.0
   webview_flutter_wkwebview: ^3.7.3
   webview_flutter_android: ^3.9.3
   crypto: ^3.0.3
   uuid: ^3.0.7
-  secp256r1: ^0.1.0-dev.7
+  secp256r1:
+    git: https://github.com/Ariflo/flutter_secp256r1
 
 dev_dependencies:
   flutter_test:

--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   crypto: ^3.0.3
   uuid: ^3.0.7
   secp256r1:
-    git: https://github.com/Ariflo/flutter_secp256r1
+    git: https://github.com/magiclabs/flutter_secp256r1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
As reported on issue https://github.com/magiclabs/magic-flutter/issues/45 our Flutter SDK which currently depends on `agent_dart v1.0.0-dev.15` cannot run on the latest iOS development platform.

This PR does the following to address the issues:

- Forks the [secp256r1](https://github.com/Ariflo/flutter_secp256r1) dependency we use for DPoP and updates the `agent_dart` dependency to the latest `v1.0.0-dev.18` where the [parseErrorData](https://github.com/AstroxNetwork/agent_dart/issues/70) described in issue https://github.com/magiclabs/magic-flutter/issues/45 has been [resolved](https://github.com/AstroxNetwork/agent_dart/pull/69)

- Applies all the subsequent updates required with the move to `v1.0.0-dev.18` (ie. `web3dart` > `2.7.0`, `package_info_plus` >`^4.2.0`, `Solana` > `0.30.0`)

- Updates demo app to match latest versioning, one caveat being @Ethella I need collaboration access to your fork => https://github.com/Ethella/tezart to update [this line](https://github.com/Ethella/tezart/blob/main/pubspec.yaml#L18), [this line](https://github.com/Ethella/tezart/blob/0c57500ae7955000562920e2e2eb99b00617a231/lib/src/signature/impl/signature.dart#L77), and [this line.](https://github.com/Ethella/tezart/blob/0c57500ae7955000562920e2e2eb99b00617a231/lib/src/crypto/impl/encrypted_secret_key_to_seed.dart#L24)

More notes:

- These updates *** DO NOT *** resolve the problem with running our SDK with the latest version of iOS 😢 . I've posted an issue with: [secp256r1](https://github.com/AstroxNetwork/flutter_secp256r1/issues/7), [Apple](https://developer.apple.com/forums/thread/738672?login=true&page=1#771390022), and [agent_dart](https://github.com/AstroxNetwork/agent_dart/issues/71)  in hopes that the development community can help me resolve this issue. 

- That said, this solution works on Android, and ergo may still be worth releasing to our developers. 