### PR TITLE
Point secp256r1 dependency back to version ^0.1.0-dev.7

### DIFF
--- a/packages/magic_sdk/pubspec.yaml
+++ b/packages/magic_sdk/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   webview_flutter_android: ^3.9.3
   crypto: ^3.0.3
   uuid: ^3.0.7
-  secp256r1:
-    git: https://github.com/magiclabs/flutter_secp256r1
+  secp256r1: ^0.1.0-dev.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Integrate fix by `agent_dart` dev: https://github.com/AstroxNetwork/agent_dart/issues/71